### PR TITLE
vm: Added dispatch table

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-STD=-std=c11
-override CFLAGS+=-Werror -Wall -g -fPIC -O2 -DNDEBUG -ftrapv -Wfloat-equal -Wundef -Wwrite-strings -Wconversion -Wuninitialized -pedantic
+STD=-std=gnu
+override CFLAGS+=-Werror -Wall -g -fPIC -O2 -DNDEBUG -ftrapv -Wfloat-equal -Wundef -Wwrite-strings -Wconversion -Wuninitialized
 DEBUG+=-DDEBUG_ON
 PREFIX=/usr/bin/
 BUILDDIR=bin/


### PR DESCRIPTION
This PR adds dispatch tables as described in [this blogpost](https://eli.thegreenplace.net/2012/07/12/computed-goto-for-efficient-dispatch-tables/). It works, but I’m unsure whether it actually speeds things up (the benchmarks are all to small). It also means one has to compile with GCC, as Clang doesn’t seem to support this extension.

So, for now, this is just saved for posteriority.